### PR TITLE
Added class red-error to demonstrate hyphen use

### DIFF
--- a/src/ng/directive/ngClass.js
+++ b/src/ng/directive/ngClass.js
@@ -162,7 +162,7 @@ function classDirective(name, selector) {
  * @example Example that demonstrates basic bindings via ngClass directive.
    <example>
      <file name="index.html">
-       <p ng-class="{strike: deleted, bold: important, red: error}">Map Syntax Example</p>
+       <p ng-class="{strike: deleted, bold: important, 'red-error': error}">Map Syntax Example</p>
        <label>
           <input type="checkbox" ng-model="deleted">
           deleted (apply "strike" class)
@@ -201,6 +201,10 @@ function classDirective(name, selector) {
        }
        .red {
            color: red;
+       }
+       .red-error {
+           color: red;
+           background-color: yellow;
        }
        .orange {
            color: orange;


### PR DESCRIPTION
Because hyphens, such as those you find in the Bootstrap theme, require special handling (quotes) when ngClass uses an object.